### PR TITLE
Feature/ms coco yolo converter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ config.json
 /Model/keras-importer/obj
 /Model/pytorch-importer/obj
 /Model/tesseract-integrator/obj
+

--- a/Preprocessing/Output/.gitignore
+++ b/Preprocessing/Output/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/Preprocessing/notebooks/coco-converter.dib
+++ b/Preprocessing/notebooks/coco-converter.dib
@@ -118,11 +118,21 @@ type CocoJson = {
 let filesInDirectory = Directory.GetFiles(EnvironmentVariable.MSCOCO_ANNOTATION_FOLDER_INPUT);
 
 let mutable jsonContent: CocoJson array = [||];
+let mutable cocoTypes: string array = [||];
 
 for i in filesInDirectory do
     let jsonString = File.ReadAllText(i);
+    let fileName = Path.GetFileName(i).ToLower();
+
     let importedData: CocoJson = JsonConvert.DeserializeObject<CocoJson>(jsonString);
+
+    let cocoFileType = if fileName.Contains("test") then "Test"
+                        elif fileName.Contains("train") then "Train"
+                        elif fileName.Contains("val") then "Val"
+                        else "Unknown";
+
     jsonContent <- Array.append jsonContent [| importedData |];
+    cocoTypes <- Array.append cocoTypes [| cocoFileType |];
 
 jsonContent.Length;
 
@@ -193,8 +203,12 @@ for src in 0 .. (jsonContent.Length - 1) do
                                         + i.bbox[2].ToString() 
                                         + " " 
                                         + i.bbox[3].ToString();
+        
+        let folderPath = outputFolderPath + "/" + cocoTypes.[src] + "/";
 
-        use stream = new StreamWriter ((outputFolderPath + RemoveExtensionFromFileName(image.file_name) + ".txt"), false);
+        Directory.CreateDirectory(folderPath) |> ignore;
+
+        use stream = new StreamWriter ((folderPath + RemoveExtensionFromFileName(image.file_name) + ".txt"), false);
         stream.WriteLine(annotationString);
 
         stream.Close();

--- a/Preprocessing/notebooks/coco-converter.dib
+++ b/Preprocessing/notebooks/coco-converter.dib
@@ -4,4 +4,199 @@
 
 #!fsharp
 
-printfn "Hello world"
+#r "nuget: Newtonsoft.Json, 13.0.3"
+
+#!fsharp
+
+open System;
+open System.IO;
+open Newtonsoft.Json;
+open System.Linq;
+open System.Net.Http;
+
+#!markdown
+
+# Environment Variable
+
+#!fsharp
+
+type RegisteredKeys = {
+    TELEGRAM_BOT_ID: string
+    CHAT_ID: int64
+    YOLO_ANNOTATION_FOLDER_OUTPUT: string
+    MSCOCO_ANNOTATION_FOLDER_INPUT: string
+};
+
+let EnvironmentVariable : RegisteredKeys =
+    let envPath: string = "../../config.json";
+    
+    let environmentVariableJsonFile = File.ReadAllText(envPath);
+
+    let configurationValue: RegisteredKeys = JsonConvert.DeserializeObject<RegisteredKeys>(environmentVariableJsonFile);
+
+    configurationValue;
+
+
+
+    
+
+type TelegramRequestDTO = { 
+    text: string 
+    chat_id: int64
+}
+
+let telegramService (message: string) =
+    
+    // Request manipulation
+
+    let currentDateTime = DateTime.Now.ToString("yyyy-MM-dd HH:mm:ss");
+    let requestMessage = "["+currentDateTime+"] "+message;
+    let request: TelegramRequestDTO = { text = requestMessage; chat_id = EnvironmentVariable.CHAT_ID; };
+
+
+    use httpRequest = new HttpClient();
+    let json = JsonConvert.SerializeObject request;
+    use content = new StringContent (json, Encoding.UTF8, "application/json")
+
+    async {
+        let! response = httpRequest.PostAsync("https://api.telegram.org/bot"+EnvironmentVariable.TELEGRAM_BOT_ID+"/sendMessage", content) |> Async.AwaitTask
+        response;
+    } |> Async.RunSynchronously;
+
+#!markdown
+
+# Information extraction
+
+### 2023-01-30 16:11
+From what I know about the COCO thingy, it contains several informations below:
+
+1. images
+2. annotations
+3. categories
+
+For next 2 hours, just try to get these values aboves
+
+#!markdown
+
+# Model Part
+
+#!fsharp
+
+type Category = {
+    id: int
+    name: string
+};
+
+type Image = {
+    id: int
+    width: int
+    height: int
+    file_name: string
+    doc_name: string
+    page_no: int
+};
+
+type Annotation = {
+    id: int
+    image_id: int
+    category_id: int
+    bbox: float array
+};
+
+type CocoJson = {
+    categories: Category array
+    images: Image array
+    annotations: Annotation array
+};
+
+#!markdown
+
+# Deserialize the COCO file
+
+#!fsharp
+
+let filesInDirectory = Directory.GetFiles(EnvironmentVariable.MSCOCO_ANNOTATION_FOLDER_INPUT);
+
+let mutable jsonContent: CocoJson array = [||];
+
+for i in filesInDirectory do
+    let jsonString = File.ReadAllText(i);
+    let importedData: CocoJson = JsonConvert.DeserializeObject<CocoJson>(jsonString);
+    jsonContent <- Array.append jsonContent [| importedData |];
+
+jsonContent.Length;
+
+#!markdown
+
+# Data ETL
+
+1. Transform the data within categories by extracting all the data within `jsonContent.categories`, and write a file to the Preprocessing/output directory as "categories file" with rules of, every categories id must be substract by 1.
+
+2. Make a LinQ array searching method to search image by id.
+
+3. For
+
+#!fsharp
+
+// Categories Extractor
+
+let mutable categoriesExtrationResult: string = "";
+
+for i in jsonContent.[0].categories do
+    categoriesExtrationResult <- (categoriesExtrationResult + (i.id - 1).ToString() + " " + i.name + "\n");
+
+use stream = new StreamWriter ("../Output/extracted-categories.txt", false);
+stream.WriteLine(categoriesExtrationResult);
+
+stream.Close();
+
+#!markdown
+
+# Query Repository
+
+#!fsharp
+
+// Image searcher repository
+
+let FindImageById (source: int) (imageId: int): Image = 
+    let resultSet = jsonContent.[source].images |> Array.filter(fun x -> x.id = imageId);
+
+    resultSet[0];
+
+let FindAnnotationById (source: int) (annotationId: int): Annotation = 
+    let resultSet = jsonContent.[source].annotations |> Array.filter(fun x -> x.id = annotationId);
+
+    resultSet[0];
+
+#!fsharp
+
+let outputFolderPath = EnvironmentVariable.YOLO_ANNOTATION_FOLDER_OUTPUT;
+
+let RemoveExtensionFromFileName (filename: string) =
+    let reversedString = (filename.ToCharArray()) |> Array.rev;
+    let indexOfDot = String(reversedString).IndexOf(".");
+    let substringBackSlash = reversedString.[(indexOfDot - 1) .. reversedString.Length];
+    String((substringBackSlash) |> Array.rev);
+
+telegramService "Starting generating Yolo Output from MSCOCO";
+
+for src in 0 .. (jsonContent.Length - 1) do
+    for i in jsonContent[src].annotations do
+        let image = FindImageById src i.image_id;
+
+        let annotationString = (i.category_id - 1).ToString() 
+                                        + " " 
+                                        + i.bbox[0].ToString() 
+                                        + " " 
+                                        + i.bbox[1].ToString() 
+                                        + " " 
+                                        + i.bbox[2].ToString() 
+                                        + " " 
+                                        + i.bbox[3].ToString();
+
+        use stream = new StreamWriter ((outputFolderPath + RemoveExtensionFromFileName(image.file_name) + ".txt"), false);
+        stream.WriteLine(annotationString);
+
+        stream.Close();
+
+telegramService "Done generating Yolo Output from MSCOCO";

--- a/config.json.example
+++ b/config.json.example
@@ -4,5 +4,7 @@
     "DOWNSCALED_UPSCALED_IMAGE_FOLDER_PATH": "string",
     "LABELS_ARRAY_FOLDER_PATH": "string",
     "TELEGRAM_BOT_ID": "string",
-    "CHAT_ID": -0
+    "CHAT_ID": -0,
+    "YOLO_ANNOTATION_FOLDER_OUTPUT": "string",
+    "MSCOCO_ANNOTATION_FOLDER_INPUT": "string"
 }


### PR DESCRIPTION
# MSCOCO for YOLO Converter Module

A preprocessing step is required to train the YOLO model utilizing the MSCOCO dataset format. This is required since the MSCOCO data format is not able to fit into YOLO for training directly since annotating objects in YOLO works differently. 

This pull request marks the completion of the preprocessing step for this matter. The algorithm applied within these conversions are stated as below:

1. YOLO class format
YOLO label format utilizes this format below:
`<classes> <x_center> <y_center> <width> <height>`

With MSCOCO utilizes JSON format consist of this model format:

```fsharp
type CocoJson = {
    categories: Category array
    images: Image array
    annotations: Annotation array
};

type Category = {
    id: int
    name: string
};

type Image = {
    id: int
    width: int
    height: int
    file_name: string
    doc_name: string
    page_no: int
};

type Annotation = {
    id: int
    image_id: int
    category_id: int
    bbox: float array
};
```

The extracted MSCOCO annotations and transformed YOLO format are as below:

`<annotation.category_id - 1> <annotation.bbox[0]> <annotation.bbox[1]> <annotation.bbox[2]> <annotation.bbox[3]>`

2. YOLO annotation requirements
By default, YOLO is required to set their Train, Test, and Val datasets into separate folders. This also is applied to its annotation boundary box format. In which the metadata of the image annotations, are saved as a txt file with the respective image file name. This pull request also contains a code to automate the boundary box writing system.